### PR TITLE
Add missing 'apt' dependency for puppet_agent

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,4 +11,5 @@ fixtures:
   repositories:
     provision: 'https://github.com/puppetlabs/provision.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'


### PR DESCRIPTION
Before the change notice the `UNMET DEPENDENCY puppetlabs-apt (>= 7.7.1 < 10.0.0)` beneath the puppet_agent:

```bash
➜  puppet-gitea git:(main) ✗ bera spec_prep
+ bundle exec rake spec_prep
==> rake spec_prep
...
...
➜  puppet-gitea git:(main) ✗ puppet module list --tree --modulepath=spec/fixtures/modules
Warning: Missing dependency 'puppetlabs-apt':
  'puppetlabs-puppet_agent' (v4.20.0) requires 'puppetlabs-apt' (>= 7.7.1 < 10.0.0)
/Users/gavin.didrichsen/@REFERENCES/github/app/parent/tools/gitea/forks/puppet-gitea/spec/fixtures/modules
├─┬ h0tw1r3-gitea (v3.2.0)
│ ├── puppetlabs-stdlib (v9.6.0)
│ ├── puppetlabs-inifile (v6.1.1)
│ ├── puppet-archive (v7.1.0)
│ ├── puppet-extlib (v7.0.0)
│ └── puppet-systemd (v7.0.0)
├─┬ puppetlabs-puppet_agent (v4.20.0)
│ ├── UNMET DEPENDENCY puppetlabs-apt (>= 7.7.1 < 10.0.0)
│ └── puppetlabs-facts (v1.5.0)
└── puppetlabs-provision (v2.1.1)
➜  puppet-gitea git:(main) ✗ 
```

After the change

```bash
➜  puppet-gitea git:(main) ✗ puppet module list --tree --modulepath=spec/fixtures/modules
/Users/gavin.didrichsen/@REFERENCES/github/app/parent/tools/gitea/forks/puppet-gitea/spec/fixtures/modules
├─┬ h0tw1r3-gitea (v3.2.0)
│ ├── puppetlabs-stdlib (v9.6.0)
│ ├── puppetlabs-inifile (v6.1.1)
│ ├── puppet-archive (v7.1.0)
│ ├── puppet-extlib (v7.0.0)
│ └── puppet-systemd (v7.0.0)
├─┬ puppetlabs-puppet_agent (v4.20.0)
│ ├── puppetlabs-apt (v9.4.0)
│ └── puppetlabs-facts (v1.5.0)
└── puppetlabs-provision (v2.1.1)
➜  puppet-gitea git:(main) ✗ 
```
